### PR TITLE
Environment variables

### DIFF
--- a/alarm-monitor.py
+++ b/alarm-monitor.py
@@ -1023,12 +1023,12 @@ def garage_pir_active(zone, old_state, new_state):
 
 
 if __name__ == '__main__':
-    texhost = '192.168.1.9'
-    texport = 10001
+    texhost = os.getenv('TEXHOST','192.168.1.9')
+    texport = os.getenv('TEXPORT',10001)
     # This is the default UDL password for a factory panel. For any real
     # installation, use wintex to set the UDL password in the panel to a
     # random 16 character alphanumeric string.
-    udlpassword = '1234'
+    udlpassword = os.getenv('UDLPASSWORD','1234')
 
     sys.stdout = Unbuffered(sys.stdout)
     tc = TexecomConnect(texhost, texport, udlpassword, message_handler)


### PR DESCRIPTION
Allow texhost, texport, udlpassword to be set via env vars