### PR TITLE
Get lcd display instead of time for keepalive

### DIFF
--- a/texecomConnect.py
+++ b/texecomConnect.py
@@ -401,7 +401,7 @@ class TexecomConnect(object):
                 # this ends up recursively calling recvresponse; however as our retry * timeout (3 * 2 == 6) is
                 # far less than the 30 seconds between idle commands that won't be an issue
                 if self.lastIdleCommand == 0:
-                    result = self.get_date_time()
+                    result = self.lcddisplay()
                 elif self.lastIdleCommand == 1:
                     result = self.get_log_pointer()
                 else:


### PR DESCRIPTION
Based on the Texecom forum and the previous commit history it looks like the command to get the time might be causing issues, so swap to the lcd display